### PR TITLE
Add Windows packaging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,8 @@ out
 
 # Nuxt.js
 .nuxt
-dist
+# allow packaging artifacts
+!dist/
 
 # Gatsby
 .cache/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ pip install -r requirements.txt
 python -m app.main
 ```
 
+### Building Windows Executable
+
+To create a standalone Windows `AutoClipper.exe` run `build_installer.bat` from a
+Windows command prompt. The script downloads required binaries and bundles
+Python using PyInstaller. The resulting executable is placed in the `dist`
+folder.
+
 ## Support
 
 For issues or feature requests, please contact [github.com/jakeefr]

--- a/app/main.py
+++ b/app/main.py
@@ -2,9 +2,10 @@ import customtkinter as ctk
 from tkinter import messagebox
 import threading
 import os
+import sys
 from pathlib import Path
 
-from .clipper import download_and_clip_playlist
+from .clipper import download_and_clip_playlist, ensure_binaries
 
 
 class AutoClipperApp(ctk.CTk):
@@ -130,6 +131,8 @@ class AutoClipperApp(ctk.CTk):
 
 
 def main():
+    base_dir = Path(sys.executable).resolve().parent if getattr(sys, "frozen", False) else Path(__file__).resolve().parent
+    ensure_binaries(base_dir, lambda _m: None)
     app = AutoClipperApp()
     app.mainloop()
 

--- a/autoclipper.spec
+++ b/autoclipper.spec
@@ -1,0 +1,46 @@
+# -*- mode: python ; coding: utf-8 -*-
+import sys
+from pathlib import Path
+
+block_cipher = None
+
+base_path = Path(__file__).parent
+
+
+a = Analysis(
+    ['app/main.py'],
+    pathex=[str(base_path)],
+    binaries=[('ffmpeg.exe', '.'), ('ffprobe.exe', '.'), ('yt-dlp.exe', '.')],
+    datas=[],
+    hiddenimports=['customtkinter', 'ffmpeg'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='AutoClipper',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    name='AutoClipper',
+)

--- a/build_installer.bat
+++ b/build_installer.bat
@@ -1,0 +1,5 @@
+@echo off
+REM Build AutoClipper Windows executable
+python -m pip install --upgrade pyinstaller >nul
+python fetch_binaries.py
+pyinstaller --onefile --noconsole --add-data "ffmpeg.exe;." --add-data "ffprobe.exe;." --add-data "yt-dlp.exe;." --name AutoClipper app\main.py --distpath dist

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,2 @@
+This directory will contain the generated AutoClipper Windows executable.
+Run `build_installer.bat` on Windows to build `AutoClipper.exe` here.

--- a/fetch_binaries.py
+++ b/fetch_binaries.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import urllib.request
+import zipfile
+
+def download(url: str, dest: Path):
+    print(f"Downloading {url}...")
+    with urllib.request.urlopen(url) as r, open(dest, "wb") as f:
+        f.write(r.read())
+
+
+def main():
+    base = Path(__file__).parent
+    ytdlp = base / "yt-dlp.exe"
+    if not ytdlp.exists():
+        download("https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe", ytdlp)
+
+    ffmpeg = base / "ffmpeg.exe"
+    ffprobe = base / "ffprobe.exe"
+    if not ffmpeg.exists() or not ffprobe.exists():
+        tmp = base / "ffmpeg.zip"
+        download("https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip", tmp)
+        with zipfile.ZipFile(tmp) as z:
+            for m in z.namelist():
+                if m.endswith("ffmpeg.exe"):
+                    z.extract(m, base)
+                    (base / m).rename(ffmpeg)
+                if m.endswith("ffprobe.exe"):
+                    z.extract(m, base)
+                    (base / m).rename(ffprobe)
+        tmp.unlink()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add auto-downloading for `yt-dlp`, `ffmpeg` and `ffprobe`
- build PyInstaller spec for bundling to a single exe
- provide Windows build script and helper downloader
- keep dist artifacts in repo
- document Windows build instructions

## Testing
- `python -m py_compile app/*.py`


------