### PR TITLE
Improve playlist handling and logging

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,17 @@
 from pathlib import Path
+import os
+import sys
 
 
 def ensure_dir(path: Path) -> Path:
     path.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def get_output_folder() -> Path:
+    """Return the consistent output folder for clips."""
+    if sys.platform == "win32":
+        base = Path(os.environ.get("USERPROFILE", str(Path.home()))) / "Videos" / "AutoClipperApp"
+    else:
+        base = Path.home() / "Videos" / "AutoClipperApp"
+    return ensure_dir(base)


### PR DESCRIPTION
## Summary
- add helper to consistently choose output folder
- style context menu with theme colors
- improve error handling and add session logging
- skip failed downloads and ffmpeg errors gracefully

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ffmpeg -version | head -n 2`
- `yt-dlp --version`


------
https://chatgpt.com/codex/tasks/task_e_6880602161e8832cb3d03205a64c4126