### PR TITLE
Simplify output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ AutoClipper is a standalone Windows desktop application that downloads YouTube p
 Clips are saved to:
 
 ```
-C:\Users\YourName\Videos\AutoClipper_YYYY-MM-DD_HH-MM-SS\
+C:\Users\YourName\Videos\AutoClipperApp\
 ```
 
-Each video gets its own subfolder under the timestamped session folder.
+All videos and clips are placed directly inside this folder.
 
 ---
 

--- a/app/clipper.py
+++ b/app/clipper.py
@@ -94,8 +94,6 @@ def download_and_clip_playlist(
         edge_path = Path(os.environ.get("USERPROFILE", "")) / "AppData" / "Local" / "Microsoft" / "Edge"
         browser = "edge" if edge_path.exists() else "chrome"
 
-    session_dir = output_dir / "session"
-    session_dir.mkdir(exist_ok=True)
 
     info_cmd = [
         str(ytdlp_path),
@@ -125,7 +123,7 @@ def download_and_clip_playlist(
         if duration > 20 * 60:
             log_callback(f"Skipping {title} (longer than 20 min)")
             continue
-        out_file = session_dir / f"{vid_id}.{format}"
+        out_file = output_dir / f"{vid_id}.{format}"
         if out_file.exists():
             log_callback(f"Using cached {out_file.name}")
             videos.append((title, out_file))


### PR DESCRIPTION
## Summary
- save videos directly in the output folder
- update docs to reflect the fixed output path

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint`

------